### PR TITLE
Respect X-Forwarded-Host header

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ function wellKnownJSON(options, resources) {
         var m = req.path.match(WELL_KNOWN);
         var base = options.baseUri ||
                 (req.headers['x-forwarded-proto'] || req.protocol) + '://' +
-                req.headers.host;
+                (req.headers['x-forwarded-host'] || req.headers.host);
 
         if (!m || !m[1] || !json[m[1]]) {
             return next();

--- a/test/well-know-json.test.js
+++ b/test/well-know-json.test.js
@@ -168,7 +168,7 @@ describe('wkj', function() {
             .end(done);
     });
 
-    it('should respect X-Forward-Proto', function(done) {
+    it('should respect X-Forwarded-Proto', function(done) {
         var resource = {
             uri: './thing'
         };
@@ -184,6 +184,25 @@ describe('wkj', function() {
             .expect(function(res) {
                 return res.body.uri !== 'test://' + res.req._headers.host +
                     '/thing';
+            })
+            .end(done);
+    });
+
+    it('should respect X-Forwarded-Host', function(done) {
+        var resource = {
+            uri: './thing'
+        };
+        var app = express();
+        var middleware = wkj({});
+        app.use(middleware);
+
+        middleware.addResource('foo', resource);
+
+        request(app)
+            .get('/.well-known/foo')
+            .set('X-Forwarded-Host', 'test.test:7')
+            .expect(function(res) {
+                return res.body.uri !== 'http://test.test:7/thing';
             })
             .end(done);
     });


### PR DESCRIPTION
If we handle the forwarded protocol (X-Forwarded-Proto), seems like we should handle the forwarded host as well. Since you added the proto part, maybe give this a once over before pulling @abalmos.

Also, woo TDD :goat:.